### PR TITLE
phone 구현

### DIFF
--- a/database/models/student.model.ts
+++ b/database/models/student.model.ts
@@ -26,7 +26,7 @@ export default class Student extends Model<Student> {
 
   @ForeignKey(() => User)
   @AllowNull(false)
-  @Column(DataType.INTEGER)
+  @Column(DataType.UUID)
   public user_pk: string;
 
   @AllowNull(false)

--- a/database/models/teacher.model.ts
+++ b/database/models/teacher.model.ts
@@ -25,7 +25,7 @@ export default class Teacher extends Model<Teacher> {
 
   @ForeignKey(() => User)
   @AllowNull(false)
-  @Column(DataType.INTEGER)
+  @Column(DataType.UUID)
   public user_pk: string;
 
   @AllowNull(false)

--- a/database/models/user.model.ts
+++ b/database/models/user.model.ts
@@ -18,11 +18,11 @@ import Teacher from './teacher.model';
   timestamps: true,
 })
 export default class User extends Model<User> {
-  @AutoIncrement
   @PrimaryKey
   @AllowNull(false)
-  @Column(DataType.INTEGER)
-  public pk: number;
+  @Default(DataType.UUIDV4)
+  @Column(DataType.UUID)
+  public pk: string;
 
   @AllowNull(false)
   @Column(DataType.STRING)
@@ -45,6 +45,9 @@ export default class User extends Model<User> {
   @AllowNull(false)
   @Column(DataType.STRING)
   public signKey: string;
+
+  @Column(DataType.STRING)
+  public tp: string;
 
   @CreatedAt
   public createdAt: Date;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@types/swagger-ui-express": "^3.0.0",
+    "axios": "^0.18.0",
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
     "express-validator": "^5.3.1",

--- a/routes/controllers/dev.controller.ts
+++ b/routes/controllers/dev.controller.ts
@@ -1,8 +1,7 @@
 import { NextFunction, Request, Response, Router } from 'express';
-
-import CustomError from '@Middleware/error/customError';
 import * as swaggerUiExpress from 'swagger-ui-express';
 
+import CustomError from '@Middleware/error/customError';
 import Errors from '@Middleware/error/errors';
 
 import * as swaggerJson from '../../swagger.json';

--- a/routes/controllers/verify.controller.ts
+++ b/routes/controllers/verify.controller.ts
@@ -15,14 +15,27 @@ import login from '@Middleware/verify/login/login';
 import registerValidation from '@Middleware/verify/register/_validation';
 import register from '@Middleware/verify/register/register';
 
+// phone
+import phoneValidation from '@Middleware/verify/phone/_validation';
+import fbIssueToken from '@Middleware/verify/phone/fbIssueToken';
+import phoneCheck from '@Middleware/verify/phone/phoneCheck';
+import phoneInsert from '@Middleware/verify/phone/phoneInsert';
+import stateValidation from '@Middleware/verify/phone/state/_validation';
+import stateReturn from '@Middleware/verify/phone/state/stateReturn';
+import stateCheck from '@Middleware/verify/phone/stateCheck';
+
 const router = Router();
 
 router.post('/register', registerValidation);
 router.post('/login', loginValidation);
+router.post('/phone', phoneValidation);
+router.post('/phone/state', stateValidation);
 
 router.use(checkValidation);
 
 router.post('/register', userExistCheck, signKeyCheck, passwordEncryption, register);
 router.post('/login', userExistCheck, passwordEncryption, login, issueToken);
+router.post('/phone', signKeyCheck, stateCheck, fbIssueToken, phoneCheck, phoneInsert);
+router.post('/phone/state', signKeyCheck, stateReturn);
 
 export default router;

--- a/routes/controllers/verify.controller.ts
+++ b/routes/controllers/verify.controller.ts
@@ -3,15 +3,17 @@ import { Router } from 'express';
 // common
 import checkValidation from '@Middleware/common/checkValidation';
 import passwordEncryption from '@Middleware/verify/common/passwordEncryption';
+
 // register
 import userExistCheck from '@Middleware/verify/common/userExistCheck';
 import issueToken from '@Middleware/verify/jwt/issueToken';
+import signKeyCheck from '@Middleware/verify/register/signKeyCheck';
+
 // login
 import loginValidation from '@Middleware/verify/login/_validation';
 import login from '@Middleware/verify/login/login';
 import registerValidation from '@Middleware/verify/register/_validation';
 import register from '@Middleware/verify/register/register';
-import signKeyCheck from '@Middleware/verify/register/signKeyCheck';
 
 const router = Router();
 

--- a/routes/middlewares/verify/common/passwordEncryption.ts
+++ b/routes/middlewares/verify/common/passwordEncryption.ts
@@ -12,12 +12,10 @@ const passwordEncryption = (req: Request, res: Response, next: NextFunction) => 
     const salt = res.locals.user.passwordKey || randomBytes(saltSize).toString('base64');
     const key = pbkdf2Sync(password, salt, iteration, encryptionSize, algorithm).toString('base64');
 
-    res.locals = {
-      ...res.locals,
-      temp: {
-        password: key,
-        passwordKey: salt,
-      },
+    res.locals.temp = {
+      ...res.locals.temp,
+      password: key,
+      passwordKey: salt,
     };
     next();
   } catch (error) {

--- a/routes/middlewares/verify/jwt/issueToken.ts
+++ b/routes/middlewares/verify/jwt/issueToken.ts
@@ -17,7 +17,6 @@ const issueToken = (req: Request, res: Response, next: NextFunction) => {
     data: {
       accessToken,
       user: {
-        pk: user.pk,
         type: user.type,
         admin: user.admin,
         name: (user.student && user.student.name) || user.teacher.name,

--- a/routes/middlewares/verify/phone/_validation.ts
+++ b/routes/middlewares/verify/phone/_validation.ts
@@ -1,0 +1,5 @@
+import { body, ValidationChain } from 'express-validator/check';
+
+const phoneValidation: ValidationChain[] = [body('code').isString(), body('state').isUUID(), body('signKey').isString()];
+
+export default phoneValidation;

--- a/routes/middlewares/verify/phone/fbIssueToken.ts
+++ b/routes/middlewares/verify/phone/fbIssueToken.ts
@@ -1,0 +1,51 @@
+import axios, { AxiosResponse } from 'axios';
+import { NextFunction, Request, Response } from 'express';
+import * as qs from 'querystring';
+
+import CustomError from '@Middleware/error/customError';
+import * as fbConfig from '../../../../config/facebook.json';
+
+const fbIssueToken = async (req: Request, res: Response, next: NextFunction) => {
+  const fbIssueUrl = `https://graph.accountkit.com/${fbConfig.version}/access_token?`;
+  const fbVerifyUrl = `https://graph.accountkit.com/${fbConfig.version}/me?`;
+  const query = {
+    grant_type: 'authorization_code',
+    code: req.body.code,
+    access_token: ['AA', fbConfig.appId, fbConfig.appSecret].join('|'),
+  };
+
+  try {
+    const fbIssueResponse: AxiosResponse<{
+      id: string;
+      access_token: string;
+      token_refresh_interval_sec: number;
+    }> = await axios.get(fbIssueUrl + qs.stringify(query));
+
+    const fbVerifyResponse: AxiosResponse<{
+      id: string;
+      phone: {
+        number: string;
+        country_prefix: string;
+        national_number: string;
+      };
+      application: {
+        id: string;
+      };
+    }> = await axios.get(`${fbVerifyUrl}access_token=${fbIssueResponse.data.access_token}`);
+
+    if (fbVerifyResponse.data.application.id === fbConfig.appId) {
+      res.locals.temp = {
+        ...res.locals.temp,
+        tp: fbVerifyResponse.data.phone.national_number,
+      };
+      next();
+    } else {
+      throw new Error();
+    }
+  } catch (error) {
+    console.log('code 에러');
+    next(new CustomError({ name: 'Wrong_Request' }));
+  }
+};
+
+export default fbIssueToken;

--- a/routes/middlewares/verify/phone/phoneCheck.ts
+++ b/routes/middlewares/verify/phone/phoneCheck.ts
@@ -1,0 +1,25 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+import User from '@Model/user.model';
+
+const phoneCheck = (req: Request, res: Response, next: NextFunction) => {
+  User.findOne({
+    where: {
+      tp: res.locals.temp.tp,
+    },
+  })
+    .then(user => {
+      if (user) {
+        next(new CustomError({ name: 'Exist_User', message: '사용 중인 전화번호입니다.' }));
+      } else {
+        next();
+      }
+    })
+    .catch(err => {
+      console.log(err);
+      next(new CustomError({ name: 'Database_Error' }));
+    });
+};
+
+export default phoneCheck;

--- a/routes/middlewares/verify/phone/phoneInsert.ts
+++ b/routes/middlewares/verify/phone/phoneInsert.ts
@@ -1,0 +1,22 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+import User from '@Model/user.model';
+
+const phoneInsert = async (req: Request, res: Response, next: NextFunction) => {
+  const user: User = res.locals.user;
+
+  try {
+    await user.update({
+      tp: res.locals.temp.tp,
+    });
+    await res.json({
+      success: true,
+    });
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default phoneInsert;

--- a/routes/middlewares/verify/phone/state/_validation.ts
+++ b/routes/middlewares/verify/phone/state/_validation.ts
@@ -1,0 +1,5 @@
+import { body, ValidationChain } from 'express-validator/check';
+
+const stateValidation: ValidationChain[] = [body('signKey').isString()];
+
+export default stateValidation;

--- a/routes/middlewares/verify/phone/state/stateReturn.ts
+++ b/routes/middlewares/verify/phone/state/stateReturn.ts
@@ -1,0 +1,12 @@
+import { NextFunction, Request, Response } from 'express';
+
+const stateReturn = (req: Request, res: Response, next: NextFunction) => {
+  res.json({
+    success: true,
+    data: {
+      state: res.locals.user.pk,
+    },
+  });
+};
+
+export default stateReturn;

--- a/routes/middlewares/verify/phone/stateCheck.ts
+++ b/routes/middlewares/verify/phone/stateCheck.ts
@@ -1,0 +1,16 @@
+import { NextFunction, Request, Response, response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+const stateCheck = (req: Request, res: Response, next: NextFunction) => {
+  const requestState: string = req.body.state;
+  const settingState = res.locals.user.pk;
+
+  if (requestState === settingState) {
+    next();
+  } else {
+    next(new CustomError({ name: 'Wrong_Data' }));
+  }
+};
+
+export default stateCheck;

--- a/routes/middlewares/verify/register/signKeyCheck.ts
+++ b/routes/middlewares/verify/register/signKeyCheck.ts
@@ -1,4 +1,4 @@
-import { NextFunction, request, Request, response, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
 
 import CustomError from '@Middleware/error/customError';
 import User from '@Model/user.model';
@@ -14,8 +14,15 @@ const signKeyCheck = (req: Request, res: Response, next: NextFunction) => {
   })
     .then(user => {
       if (user) {
-        res.locals.user = user;
-        next();
+        if (req.path.includes('/phone')) {
+          res.locals.user = user;
+          user.tp ? res.sendStatus(204) : next();
+        } else if (user.tp) {
+          res.locals.user = user;
+          next();
+        } else {
+          next(new CustomError({ name: 'Wrong_Request' }));
+        }
       } else {
         next(new CustomError({ name: 'Not_User', message: '잘못된 키이거나 이미 회원가입을 한 유저입니다.' }));
       }

--- a/swagger.json
+++ b/swagger.json
@@ -61,6 +61,13 @@
             "name": "state",
             "description": "서버에서 받은 고유 state",
             "required": true
+          },
+          {
+            "in": "formData",
+            "type": "string",
+            "name": "signKey",
+            "description": "회원가입 키",
+            "required": true
           }
         ],
         "responses": {
@@ -68,9 +75,6 @@
             "description": "성공",
             "schema": {
               "properties": {
-                "facebookPk": {
-                  "type": "string"
-                },
                 "facebookToken": {
                   "type": "string"
                 }
@@ -81,9 +85,18 @@
       }
     },
     "/verify/phone/state": {
-      "get": {
+      "post": {
         "tags": ["verify"],
         "description": "고유 state 발급",
+        "parameters": [
+          {
+            "in": "formData",
+            "type": "string",
+            "name": "signKey",
+            "description": "회원가입 키",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "성공",
@@ -122,20 +135,6 @@
             "type": "string",
             "name": "signKey",
             "description": "회원가입 키",
-            "required": true
-          },
-          {
-            "in": "formData",
-            "type": "string",
-            "name": "facebookPk",
-            "description": "발급받은 facebookPk",
-            "required": true
-          },
-          {
-            "in": "formData",
-            "type": "string",
-            "name": "facebookToken",
-            "description": "발급받은 facebookToken",
             "required": true
           }
         ],
@@ -198,9 +197,6 @@
     "User": {
       "type": "object",
       "properties": {
-        "pk": {
-          "type": "integer"
-        },
         "type": {
           "type": "string",
           "enum": ["student", "teacher"]

--- a/swagger.json
+++ b/swagger.json
@@ -43,6 +43,61 @@
         }
       }
     },
+    "/verify/phone": {
+      "post": {
+        "tags": ["verify"],
+        "description": "전화번호 인증",
+        "parameters": [
+          {
+            "in": "formData",
+            "type": "string",
+            "name": "code",
+            "description": "FB account kit에서 응답값으로 준 code value",
+            "required": true
+          },
+          {
+            "in": "formData",
+            "type": "string",
+            "name": "state",
+            "description": "서버에서 받은 고유 state",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "성공",
+            "schema": {
+              "properties": {
+                "facebookPk": {
+                  "type": "string"
+                },
+                "facebookToken": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/verify/phone/state": {
+      "get": {
+        "tags": ["verify"],
+        "description": "고유 state 발급",
+        "responses": {
+          "200": {
+            "description": "성공",
+            "schema": {
+              "properties": {
+                "state": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/verify/register": {
       "post": {
         "tags": ["verify"],
@@ -67,6 +122,20 @@
             "type": "string",
             "name": "signKey",
             "description": "회원가입 키",
+            "required": true
+          },
+          {
+            "in": "formData",
+            "type": "string",
+            "name": "facebookPk",
+            "description": "발급받은 facebookPk",
+            "required": true
+          },
+          {
+            "in": "formData",
+            "type": "string",
+            "name": "facebookToken",
+            "description": "발급받은 facebookToken",
             "required": true
           }
         ],
@@ -110,7 +179,7 @@
                 },
                 "data": {
                   "properties": {
-                    "token": {
+                    "accessToken": {
                       "type": "string"
                     },
                     "user": {


### PR DESCRIPTION
### verify.controller.ts
- 두 개의 phone API 등록

### passwordEncryption.ts
- res.locals.temp를 전개 연산자로 초기화해주며 재사용률을 높임

### issueToken.ts
- 토큰을 발급해주며 유저의 pk를 더 이상 응답값으로 주지 않음

### fbIssueToken.ts
- 유저가 account kit을 이용해 전화번호 인증을 하고 받은 code 값을 이용해 access_token 발급 및 디코딩을 해주는 두 개의 페이스북 API 사용

### phoneCheck.ts
- 같은 폰 번호를 가진 유저를 찾는데 사용하는 미들웨어

### phoneInsert.ts
- user 모델에 전화번호를 업데이트하는 미들웨어

### stateCheck.ts
- facebook account kit에서 csrf 공격을 방지하기 위해 발급한 state가 요청값과 같은지 확인하는 미들웨어

### stateReturn.ts
- state를 유저의 pk로 응답

### signKeyCheck.ts
- register에선 전화번호를 가진 유저만이 다음 미들웨어로, phone에선 전화번호가 있는 유저는 204 응답을 받고 아니라면 다음 미들웨어로 넘어감