### PR TITLE
feat: board API & new models(board, comment, boardPatchLog, boardReportLog, graduate, parent)

### DIFF
--- a/database/models/board.model.ts
+++ b/database/models/board.model.ts
@@ -5,6 +5,7 @@ import {
   Column,
   CreatedAt,
   DataType,
+  DeletedAt,
   ForeignKey,
   HasMany,
   Model,
@@ -12,14 +13,14 @@ import {
   Table,
   UpdatedAt,
 } from 'sequelize-typescript';
-
-import NoticeLog from './noticeLog.model';
+import BoardComment from './boardComment.model';
+import BoardPatchLog from './boardPatchLog.model';
 import User from './user.model';
 
 @Table({
   timestamps: true,
 })
-export default class Notice extends Model<Notice> {
+export default class Board extends Model<Board> {
   @AutoIncrement
   @PrimaryKey
   @AllowNull(false)
@@ -27,16 +28,13 @@ export default class Notice extends Model<Notice> {
   public pk: number;
 
   @ForeignKey(() => User)
-  @AllowNull(true)
+  @AllowNull(false)
   @Column(DataType.UUID)
   public user_pk: string;
 
-  @Column(DataType.STRING)
-  public user_name: string;
-
   @AllowNull(false)
   @Column(DataType.STRING)
-  public title: string;
+  public user_name: string;
 
   @AllowNull(false)
   @Column(DataType.TEXT)
@@ -48,9 +46,17 @@ export default class Notice extends Model<Notice> {
   @UpdatedAt
   public updatedAt: Date;
 
-  @BelongsTo(() => User)
+  @DeletedAt
+  public deletedAt: Date;
+
+  @BelongsTo(() => User, {
+    onDelete: 'CASCADE',
+  })
   public user: User;
 
-  @HasMany(() => NoticeLog)
-  public noticeLog: NoticeLog;
+  @HasMany(() => BoardPatchLog)
+  public boardPatchLog: BoardPatchLog[];
+
+  @HasMany(() => BoardComment)
+  public comment: BoardComment[];
 }

--- a/database/models/boardComment.model.ts
+++ b/database/models/boardComment.model.ts
@@ -5,6 +5,7 @@ import {
   Column,
   CreatedAt,
   DataType,
+  DeletedAt,
   ForeignKey,
   HasMany,
   Model,
@@ -13,30 +14,33 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
-import NoticeLog from './noticeLog.model';
+import Board from './board.model';
+import BoardPatchLog from './boardPatchLog.model';
 import User from './user.model';
 
 @Table({
   timestamps: true,
 })
-export default class Notice extends Model<Notice> {
+export default class BoardComment extends Model<BoardComment> {
   @AutoIncrement
   @PrimaryKey
   @AllowNull(false)
   @Column(DataType.INTEGER)
   public pk: number;
 
+  @ForeignKey(() => Board)
+  @AllowNull(false)
+  @Column(DataType.INTEGER)
+  public board_pk: number;
+
   @ForeignKey(() => User)
-  @AllowNull(true)
+  @AllowNull(false)
   @Column(DataType.UUID)
   public user_pk: string;
 
-  @Column(DataType.STRING)
-  public user_name: string;
-
   @AllowNull(false)
   @Column(DataType.STRING)
-  public title: string;
+  public user_name: string;
 
   @AllowNull(false)
   @Column(DataType.TEXT)
@@ -48,9 +52,19 @@ export default class Notice extends Model<Notice> {
   @UpdatedAt
   public updatedAt: Date;
 
-  @BelongsTo(() => User)
+  @DeletedAt
+  public deletedAt: Date;
+
+  @BelongsTo(() => User, {
+    onDelete: 'CASCADE',
+  })
   public user: User;
 
-  @HasMany(() => NoticeLog)
-  public noticeLog: NoticeLog;
+  @BelongsTo(() => Board, {
+    onDelete: 'CASCADE',
+  })
+  public board: Board;
+
+  @HasMany(() => BoardPatchLog)
+  public boardPatchLog: BoardPatchLog[];
 }

--- a/database/models/boardPatchLog.model.ts
+++ b/database/models/boardPatchLog.model.ts
@@ -1,0 +1,66 @@
+import {
+  AllowNull,
+  AutoIncrement,
+  BelongsTo,
+  Column,
+  CreatedAt,
+  DataType,
+  ForeignKey,
+  Model,
+  PrimaryKey,
+  Table,
+} from 'sequelize-typescript';
+
+import Board from './board.model';
+import BoardComment from './boardComment.model';
+import User from './user.model';
+
+@Table({
+  timestamps: false,
+})
+export default class BoardPatchLog extends Model<BoardPatchLog> {
+  @AutoIncrement
+  @PrimaryKey
+  @AllowNull(false)
+  @Column(DataType.INTEGER)
+  public pk: number;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  public type: 'board' | 'comment';
+
+  @ForeignKey(() => User)
+  @AllowNull(true)
+  @Column(DataType.UUID)
+  public user_pk: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  public user_name: string;
+
+  @ForeignKey(() => Board)
+  @AllowNull(true)
+  @Column(DataType.INTEGER)
+  public board_pk: number;
+
+  @ForeignKey(() => BoardComment)
+  @AllowNull(true)
+  @Column(DataType.INTEGER)
+  public comment_pk: number;
+
+  @AllowNull(true)
+  @Column(DataType.TEXT)
+  public past_content: string;
+
+  @CreatedAt
+  public createdAt: Date;
+
+  @BelongsTo(() => User)
+  public user: User;
+
+  @BelongsTo(() => Board)
+  public board: Board;
+
+  @BelongsTo(() => BoardComment)
+  public boardComment: BoardComment;
+}

--- a/database/models/boardReportLog.model.ts
+++ b/database/models/boardReportLog.model.ts
@@ -1,0 +1,66 @@
+import {
+  AllowNull,
+  AutoIncrement,
+  BelongsTo,
+  Column,
+  CreatedAt,
+  DataType,
+  ForeignKey,
+  Model,
+  PrimaryKey,
+  Table,
+} from 'sequelize-typescript';
+
+import Board from './board.model';
+import BoardComment from './boardComment.model';
+import User from './user.model';
+
+@Table({
+  timestamps: false,
+})
+export default class BoardReportLog extends Model<BoardReportLog> {
+  @AutoIncrement
+  @PrimaryKey
+  @AllowNull(false)
+  @Column(DataType.INTEGER)
+  public pk: number;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  public type: 'board' | 'comment';
+
+  @ForeignKey(() => User)
+  @AllowNull(true)
+  @Column(DataType.UUID)
+  public user_pk: string;
+
+  @AllowNull(false)
+  @Column(DataType.STRING)
+  public user_name: string;
+
+  @ForeignKey(() => Board)
+  @AllowNull(true)
+  @Column(DataType.INTEGER)
+  public board_pk: number;
+
+  @ForeignKey(() => BoardComment)
+  @AllowNull(true)
+  @Column(DataType.INTEGER)
+  public comment_pk: number;
+
+  @AllowNull(true)
+  @Column(DataType.TEXT)
+  public content: string;
+
+  @CreatedAt
+  public createdAt: Date;
+
+  @BelongsTo(() => User)
+  public user: User;
+
+  @BelongsTo(() => Board)
+  public board: Board;
+
+  @BelongsTo(() => BoardComment)
+  public boardComment: BoardComment;
+}

--- a/database/models/graduate.model.ts
+++ b/database/models/graduate.model.ts
@@ -6,20 +6,17 @@ import {
   CreatedAt,
   DataType,
   ForeignKey,
-  HasMany,
   Model,
   PrimaryKey,
   Table,
   UpdatedAt,
 } from 'sequelize-typescript';
-
-import NoticeLog from './noticeLog.model';
 import User from './user.model';
 
 @Table({
-  timestamps: true,
+  timestamps: false,
 })
-export default class Notice extends Model<Notice> {
+export default class Graduate extends Model<Graduate> {
   @AutoIncrement
   @PrimaryKey
   @AllowNull(false)
@@ -27,20 +24,13 @@ export default class Notice extends Model<Notice> {
   public pk: number;
 
   @ForeignKey(() => User)
-  @AllowNull(true)
+  @AllowNull(false)
   @Column(DataType.UUID)
   public user_pk: string;
 
-  @Column(DataType.STRING)
-  public user_name: string;
-
   @AllowNull(false)
   @Column(DataType.STRING)
-  public title: string;
-
-  @AllowNull(false)
-  @Column(DataType.TEXT)
-  public content: string;
+  public name: string;
 
   @CreatedAt
   public createdAt: Date;
@@ -48,9 +38,8 @@ export default class Notice extends Model<Notice> {
   @UpdatedAt
   public updatedAt: Date;
 
-  @BelongsTo(() => User)
+  @BelongsTo(() => User, {
+    onDelete: 'CASCADE',
+  })
   public user: User;
-
-  @HasMany(() => NoticeLog)
-  public noticeLog: NoticeLog;
 }

--- a/database/models/noticeLog.model.ts
+++ b/database/models/noticeLog.model.ts
@@ -33,6 +33,9 @@ export default class NoticeLog extends Model<NoticeLog> {
   @Column(DataType.INTEGER)
   public notice_pk: number;
 
+  @CreatedAt
+  public createdAt: Date;
+
   @BelongsTo(() => User, {
     onDelete: 'CASCADE',
   })
@@ -42,7 +45,4 @@ export default class NoticeLog extends Model<NoticeLog> {
     onDelete: 'CASCADE',
   })
   public notice: Notice;
-
-  @CreatedAt
-  public createdAt: Date;
 }

--- a/database/models/parent.model.ts
+++ b/database/models/parent.model.ts
@@ -6,20 +6,17 @@ import {
   CreatedAt,
   DataType,
   ForeignKey,
-  HasMany,
   Model,
   PrimaryKey,
   Table,
   UpdatedAt,
 } from 'sequelize-typescript';
-
-import NoticeLog from './noticeLog.model';
 import User from './user.model';
 
 @Table({
-  timestamps: true,
+  timestamps: false,
 })
-export default class Notice extends Model<Notice> {
+export default class Parent extends Model<Parent> {
   @AutoIncrement
   @PrimaryKey
   @AllowNull(false)
@@ -27,20 +24,13 @@ export default class Notice extends Model<Notice> {
   public pk: number;
 
   @ForeignKey(() => User)
-  @AllowNull(true)
+  @AllowNull(false)
   @Column(DataType.UUID)
   public user_pk: string;
 
-  @Column(DataType.STRING)
-  public user_name: string;
-
   @AllowNull(false)
   @Column(DataType.STRING)
-  public title: string;
-
-  @AllowNull(false)
-  @Column(DataType.TEXT)
-  public content: string;
+  public name: string;
 
   @CreatedAt
   public createdAt: Date;
@@ -48,9 +38,8 @@ export default class Notice extends Model<Notice> {
   @UpdatedAt
   public updatedAt: Date;
 
-  @BelongsTo(() => User)
+  @BelongsTo(() => User, {
+    onDelete: 'CASCADE',
+  })
   public user: User;
-
-  @HasMany(() => NoticeLog)
-  public noticeLog: NoticeLog;
 }

--- a/database/models/user.model.ts
+++ b/database/models/user.model.ts
@@ -12,10 +12,13 @@ import {
   UpdatedAt,
 } from 'sequelize-typescript';
 
+import Board from './board.model';
 import Notice from './notice.model';
 import NoticeLog from './noticeLog.model';
 import Student from './student.model';
 import Teacher from './teacher.model';
+import Graduate from './graduate.model';
+import Parent from './parent.model';
 
 @Table({
   timestamps: true,
@@ -29,7 +32,7 @@ export default class User extends Model<User> {
 
   @AllowNull(false)
   @Column(DataType.STRING)
-  public type: string;
+  public type: 'student' | 'teacher' | 'graduate' | 'parent';
 
   @AllowNull(false)
   @Default(0)
@@ -60,13 +63,19 @@ export default class User extends Model<User> {
 
   @HasOne(() => Student)
   public student: Student;
-
   @HasOne(() => Teacher)
   public teacher: Teacher;
+  @HasOne(() => Graduate)
+  public graduate: Graduate;
+  @HasOne(() => Parent)
+  public parent: Parent;
 
   @HasMany(() => Notice)
   public notice: Notice[];
 
   @HasMany(() => NoticeLog)
   public noticeLog: NoticeLog[];
+
+  @HasMany(() => Board)
+  public board: Board[];
 }

--- a/routes/apiController.ts
+++ b/routes/apiController.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 
+import board from '@Controller/board.controller';
 import calendar from '@Controller/calendar.controller';
 import dev from '@Controller/dev.controller';
 import meal from '@Controller/meal.controller';
@@ -22,5 +23,6 @@ router.use('/timetable', timetable);
 router.use('/calendar', calendar);
 router.use('/notice', notice);
 router.use('/meal', meal);
+router.use('/board', board);
 
 export default router;

--- a/routes/controllers/board.controller.ts
+++ b/routes/controllers/board.controller.ts
@@ -1,0 +1,57 @@
+import { Router } from 'express';
+
+// validation
+import deleteCommentValidation from '@Middleware/board/comment/delete/_validation';
+import getCommentValidation from '@Middleware/board/comment/get/_validation';
+import patchCommentValidation from '@Middleware/board/comment/patch/_validation';
+import PostCommentValidation from '@Middleware/board/comment/post/_validation';
+import deleteBoardValidation from '@Middleware/board/delete/_validation';
+import getBoardValidation from '@Middleware/board/get/_validation';
+import patchBoardValidation from '@Middleware/board/patch/_validation';
+import postBoardValidation from '@Middleware/board/post/_validation';
+import reportValidation from '@Middleware/board/report/_validation';
+import checkValidation from '@Middleware/common/checkValidation';
+
+// common
+import checkUserType from '@Middleware/board/common/checkUserType';
+
+// board
+import deleteBoard from '@Middleware/board/delete/deleteBoard';
+import getBoard from '@Middleware/board/get/getBoard';
+import patchBoard from '@Middleware/board/patch/patchBoard';
+import postBoard from '@Middleware/board/post/postBoard';
+
+// report
+import report from '@Middleware/board/report/report';
+
+// comment
+import deleteComment from '@Middleware/board/comment/delete/deleteComment';
+import getComment from '@Middleware/board/comment/get/getComment';
+import patchComment from '@Middleware/board/comment/patch/patchComment';
+import postComment from '@Middleware/board/comment/post/postComment';
+
+const router: Router = Router();
+
+router.get('/', getBoardValidation);
+router.post('/', checkUserType, postBoardValidation);
+router.patch('/', checkUserType, patchBoardValidation);
+router.delete('/', checkUserType, deleteBoardValidation);
+router.post('/report', reportValidation);
+router.get('/comment', getCommentValidation);
+router.post('/comment', checkUserType, PostCommentValidation);
+router.patch('/comment', checkUserType, patchCommentValidation);
+router.delete('/comment', checkUserType, deleteCommentValidation);
+
+router.use(checkValidation);
+
+router.get('/', getBoard);
+router.post('/', postBoard);
+router.patch('/', patchBoard);
+router.delete('/', deleteBoard);
+router.post('/report', report);
+router.get('/comment', getComment);
+router.post('/comment', postComment);
+router.patch('/comment', patchComment);
+router.delete('/comment', deleteComment);
+
+export default router;

--- a/routes/middlewares/board/comment/delete/_validation.ts
+++ b/routes/middlewares/board/comment/delete/_validation.ts
@@ -1,0 +1,5 @@
+import { query, ValidationChain } from 'express-validator/check';
+
+const deleteCommentValidation: ValidationChain[] = [query('board_pk').isInt(), query('comment_pk').isInt()];
+
+export default deleteCommentValidation;

--- a/routes/middlewares/board/comment/delete/deleteComment.ts
+++ b/routes/middlewares/board/comment/delete/deleteComment.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+import BoardComment from '@Model/boardComment.model';
+import User from '@Model/user.model';
+
+const deleteComment = async (req: Request, res: Response, next: NextFunction) => {
+  const board_pk = req.query.board_pk;
+  const comment_pk = req.query.comment_pk;
+  const user: User = res.locals.user;
+
+  try {
+    const comment = await BoardComment.findOne({
+      where: {
+        pk: comment_pk,
+        board_pk,
+        user_pk: user.pk,
+      },
+    });
+
+    if (comment) {
+      await comment.destroy();
+      await res.json({
+        success: true,
+      });
+    } else {
+      next(new CustomError({ name: 'Wrong_Data' }));
+    }
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default deleteComment;

--- a/routes/middlewares/board/comment/get/_validation.ts
+++ b/routes/middlewares/board/comment/get/_validation.ts
@@ -1,0 +1,10 @@
+import { query, ValidationChain } from 'express-validator/check';
+
+const getCommentValidation: ValidationChain[] = [
+  query('board_pk').isInt(),
+  query('page')
+    .optional()
+    .isInt(),
+];
+
+export default getCommentValidation;

--- a/routes/middlewares/board/comment/get/getComment.ts
+++ b/routes/middlewares/board/comment/get/getComment.ts
@@ -1,0 +1,48 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import BoardComment from '@Model/boardComment.model';
+import BoardPatchLog from '@Model/boardPatchLog.model';
+
+const getComment = async (req: Request, res: Response, next: NextFunction) => {
+  const limit = 10;
+  const page: number = (req.query.page && req.query.page - 1) || 0;
+  const board_pk: number = req.query.board_pk;
+
+  try {
+    const result = await BoardComment.findAll({
+      where: {
+        board_pk,
+      },
+      limit,
+      offset: page * limit,
+      order: [['createdAt', 'DESC']],
+      attributes: ['pk', 'user_name', 'content', 'createdAt'],
+      include: [
+        {
+          model: BoardPatchLog,
+          attributes: ['pk'],
+        },
+      ],
+    }).map((val: BoardComment) => ({
+      pk: val.pk,
+      user_name: val.user_name,
+      content: val.content,
+      createdAt: val.createdAt,
+      edited: !!val.boardPatchLog.length,
+    }));
+
+    await res.json({
+      success: true,
+      data: {
+        comment: result,
+      },
+    });
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default getComment;

--- a/routes/middlewares/board/comment/patch/_validation.ts
+++ b/routes/middlewares/board/comment/patch/_validation.ts
@@ -1,0 +1,11 @@
+import { body, query, ValidationChain } from 'express-validator/check';
+
+const patchCommentValidation: ValidationChain[] = [
+  query('board_pk').isInt(),
+  query('comment_pk').isInt(),
+  body('content')
+    .isString()
+    .isLength({ max: 300 }),
+];
+
+export default patchCommentValidation;

--- a/routes/middlewares/board/comment/patch/patchComment.ts
+++ b/routes/middlewares/board/comment/patch/patchComment.ts
@@ -1,0 +1,57 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import BoardComment from '@Model/boardComment.model';
+import BoardPatchLog from '@Model/boardPatchLog.model';
+import User from '@Model/user.model';
+
+const patchComment = async (req: Request, res: Response, next: NextFunction) => {
+  const board_pk: number = req.query.board_pk;
+  const comment_pk: number = req.query.comment_pk;
+  const content: string = req.body.content;
+  const user: User = res.locals.user;
+
+  try {
+    const past_comment: BoardComment = await BoardComment.findOne({
+      where: {
+        pk: comment_pk,
+        board_pk,
+        user_pk: user.pk,
+      },
+    });
+
+    if (past_comment && past_comment.content !== content) {
+      const now_comment: BoardComment = await past_comment.update({
+        content,
+        updatedAt: new Date(),
+      });
+
+      await BoardPatchLog.create({
+        type: 'comment',
+        user_pk: user.pk,
+        user_name: user[user.type].name,
+        board_pk,
+        comment_pk,
+        past_content: past_comment.content,
+      });
+
+      await res.json({
+        success: true,
+        data: {
+          pk: now_comment.pk,
+          user_name: now_comment.user_name,
+          content: now_comment.content,
+          createdAt: now_comment.createdAt,
+        },
+      });
+    } else {
+      next(new CustomError({ name: 'Wrong_Data' }));
+    }
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default patchComment;

--- a/routes/middlewares/board/comment/post/_validation.ts
+++ b/routes/middlewares/board/comment/post/_validation.ts
@@ -1,0 +1,10 @@
+import { body, query } from 'express-validator/check';
+
+const PostCommentValidation = [
+  query('board_pk').isInt(),
+  body('content')
+    .isString()
+    .isLength({ max: 300 }),
+];
+
+export default PostCommentValidation;

--- a/routes/middlewares/board/comment/post/postComment.ts
+++ b/routes/middlewares/board/comment/post/postComment.ts
@@ -1,0 +1,49 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import Board from '@Model/board.model';
+import BoardComment from '@Model/boardComment.model';
+import User from '@Model/user.model';
+
+const postComment = async (req: Request, res: Response, next: NextFunction) => {
+  const board_pk: number = req.query.board_pk;
+  const content: string = req.body.content;
+  const user: User = res.locals.user;
+
+  try {
+    const board: Board = await Board.findOne({
+      where: {
+        pk: board_pk,
+      },
+    });
+
+    if (board) {
+      const comment: BoardComment = await BoardComment.create({
+        board_pk,
+        content,
+        user_pk: user.pk,
+        user_name: user[user.type].name,
+      });
+
+      await res.json({
+        success: true,
+        data: {
+          comment: {
+            pk: comment.pk,
+            user_name: comment.user_name,
+            content: comment.content,
+            createdAt: comment.createdAt,
+          },
+        },
+      });
+    } else {
+      next(new CustomError({ name: 'Wrong_Data' }));
+    }
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default postComment;

--- a/routes/middlewares/board/common/checkUserType.ts
+++ b/routes/middlewares/board/common/checkUserType.ts
@@ -1,0 +1,17 @@
+import { NextFunction, Request, Response } from 'express';
+
+import User from '@Model/user.model';
+
+import CustomError from '@Middleware/error/customError';
+
+const checkUserType = (req: Request, res: Response, next: NextFunction) => {
+  const user: User = res.locals.user;
+
+  if (user.type === 'student' || user.type === 'graduate') {
+    next();
+  } else {
+    next(new CustomError({ name: 'Forbidden' }));
+  }
+};
+
+export default checkUserType;

--- a/routes/middlewares/board/delete/_validation.ts
+++ b/routes/middlewares/board/delete/_validation.ts
@@ -1,0 +1,5 @@
+import { query, ValidationChain } from 'express-validator/check';
+
+const deleteBoardValidation: ValidationChain[] = [query('pk').isInt()];
+
+export default deleteBoardValidation;

--- a/routes/middlewares/board/delete/deleteBoard.ts
+++ b/routes/middlewares/board/delete/deleteBoard.ts
@@ -1,0 +1,34 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import Board from '@Model/board.model';
+import User from '@Model/user.model';
+
+const deleteBoard = async (req: Request, res: Response, next: NextFunction) => {
+  const board_pk = req.query.pk;
+  const user: User = res.locals.user;
+
+  try {
+    const board: Board = await Board.findOne({
+      where: {
+        pk: board_pk,
+        user_pk: user.pk,
+      },
+    });
+
+    if (board) {
+      await board.destroy();
+      await res.json({
+        success: true,
+      });
+    } else {
+      next(new CustomError({ name: 'Wrong_Data' }));
+    }
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default deleteBoard;

--- a/routes/middlewares/board/get/_validation.ts
+++ b/routes/middlewares/board/get/_validation.ts
@@ -1,0 +1,9 @@
+import { query, ValidationChain } from 'express-validator/check';
+
+const getBoardValidation: ValidationChain[] = [
+  query('page')
+    .optional()
+    .isInt({ min: 1, max: 1000 }),
+];
+
+export default getBoardValidation;

--- a/routes/middlewares/board/get/getBoard.ts
+++ b/routes/middlewares/board/get/getBoard.ts
@@ -1,0 +1,69 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import Board from '@Model/board.model';
+import BoardComment from '@Model/boardComment.model';
+import BoardPatchLog from '@Model/boardPatchLog.model';
+
+const getBoard = async (req: Request, res: Response, next: NextFunction) => {
+  const board_limit = 10;
+  const comment_limit = 3;
+  const page = (req.query.page && req.query.page - 1) || 0;
+
+  try {
+    const result: Board[] = await Board.findAll({
+      limit: board_limit,
+      offset: page * board_limit,
+      attributes: ['pk', 'user_name', 'content', 'createdAt'],
+      order: [['createdAt', 'DESC']],
+      include: [
+        {
+          model: BoardPatchLog,
+          attributes: ['pk'],
+        },
+        {
+          model: BoardComment,
+          attributes: ['pk', 'user_name', 'content', 'createdAt'],
+          limit: comment_limit,
+          include: [
+            {
+              model: BoardPatchLog,
+              attributes: ['pk'],
+            },
+          ],
+        },
+      ],
+    }).map((val: Board) => {
+      const comments = val.comment.map(comment => ({
+        pk: comment.pk,
+        user_name: comment.user_name,
+        content: comment.content,
+        createdAt: comment.createdAt,
+        edited: !!comment.boardPatchLog.length,
+      }));
+
+      return {
+        pk: val.pk,
+        user_name: val.user_name,
+        content: val.content,
+        edited: !!val.boardPatchLog.length,
+        createdAt: val.createdAt,
+        commentLength: val.comment.length,
+        comment: comments,
+      };
+    });
+
+    res.json({
+      success: true,
+      data: {
+        board: result,
+      },
+    });
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default getBoard;

--- a/routes/middlewares/board/patch/_validation.ts
+++ b/routes/middlewares/board/patch/_validation.ts
@@ -1,0 +1,10 @@
+import { body, query, ValidationChain } from 'express-validator/check';
+
+const patchBoardValidation: ValidationChain[] = [
+  query('pk').isInt(),
+  body('content')
+    .isString()
+    .isLength({ max: 600 }),
+];
+
+export default patchBoardValidation;

--- a/routes/middlewares/board/patch/patchBoard.ts
+++ b/routes/middlewares/board/patch/patchBoard.ts
@@ -1,0 +1,54 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import Board from '@Model/board.model';
+import BoardPatchLog from '@Model/boardPatchLog.model';
+import User from '@Model/user.model';
+
+const patchBoard = async (req: Request, res: Response, next: NextFunction) => {
+  const user: User = res.locals.user;
+  const board_pk = req.query.pk;
+  const current_content = req.body.content;
+
+  try {
+    const past_board: Board = await Board.findOne({
+      where: {
+        pk: board_pk,
+        user_pk: user.pk,
+      },
+    });
+
+    if (past_board && past_board.content !== current_content) {
+      const current_board: Board = await past_board.update({
+        content: current_content,
+        updatedAt: new Date(),
+      });
+
+      await BoardPatchLog.create({
+        board_pk,
+        user_pk: user.pk,
+        past_content: past_board.content,
+      });
+
+      await res.json({
+        success: true,
+        data: {
+          board: {
+            pk: current_board.pk,
+            user_name: current_board.user_name,
+            content: current_board.content,
+            createdAt: current_board.createdAt,
+          },
+        },
+      });
+    } else {
+      next(new CustomError({ name: 'Wrong_Data' }));
+    }
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default patchBoard;

--- a/routes/middlewares/board/post/_validation.ts
+++ b/routes/middlewares/board/post/_validation.ts
@@ -1,0 +1,9 @@
+import { body, ValidationChain } from 'express-validator/check';
+
+const postBoardValidation: ValidationChain[] = [
+  body('content')
+    .isString()
+    .isLength({ max: 600 }),
+];
+
+export default postBoardValidation;

--- a/routes/middlewares/board/post/postBoard.ts
+++ b/routes/middlewares/board/post/postBoard.ts
@@ -1,0 +1,36 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import Board from '@Model/board.model';
+import User from '@Model/user.model';
+
+const postBoard = async (req: Request, res: Response, next: NextFunction) => {
+  const user: User = res.locals.user;
+  const content: string = req.body.content;
+
+  try {
+    const result: Board = await Board.create({
+      user_pk: user.pk,
+      user_name: user.student.name,
+      content,
+    });
+
+    await res.json({
+      success: true,
+      data: {
+        board: {
+          pk: result.pk,
+          user_name: result.user_name,
+          content: result.content,
+          createdAt: result.createdAt,
+        },
+      },
+    });
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default postBoard;

--- a/routes/middlewares/board/report/_validation.ts
+++ b/routes/middlewares/board/report/_validation.ts
@@ -1,0 +1,27 @@
+import { body, oneOf, query } from 'express-validator/check';
+
+const reportValidation = oneOf([
+  [
+    query('type')
+      .isString()
+      .custom(val => val === 'board'),
+    query('board_pk').isInt(),
+    body('content')
+      .optional()
+      .isString()
+      .isLength({ max: 300 }),
+  ],
+  [
+    query('type')
+      .isString()
+      .custom(val => val === 'comment'),
+    query('board_pk').isInt(),
+    query('comment_pk').isInt(),
+    body('content')
+      .optional()
+      .isString()
+      .isLength({ max: 300 }),
+  ],
+]);
+
+export default reportValidation;

--- a/routes/middlewares/board/report/report.ts
+++ b/routes/middlewares/board/report/report.ts
@@ -1,0 +1,68 @@
+import { NextFunction, Request, Response } from 'express';
+
+import CustomError from '@Middleware/error/customError';
+
+import Board from '@Model/board.model';
+import BoardComment from '@Model/boardComment.model';
+import BoardReportLog from '@Model/boardReportLog.model';
+import User from '@Model/user.model';
+
+const report = async (req: Request, res: Response, next: NextFunction) => {
+  const type: 'board' | 'comment' = req.query.type;
+  const board_pk: number = req.query.board_pk;
+  const comment_pk: number = req.query.comment_pk;
+  const content: string = req.body.content;
+  const user: User = res.locals.user;
+
+  try {
+    const shouldBeReported: Board | BoardComment =
+      type === 'board'
+        ? await Board.findOne({
+            where: {
+              pk: board_pk,
+            },
+          })
+        : await BoardComment.findOne({
+            where: {
+              pk: comment_pk,
+              board_pk,
+            },
+          });
+
+    if (shouldBeReported) {
+      const [result, created]: [BoardReportLog, boolean] = await BoardReportLog.findOrCreate({
+        where: {
+          type,
+          board_pk,
+          comment_pk: comment_pk || null,
+          user_pk: user.pk,
+        },
+        defaults: {
+          type,
+          board_pk,
+          comment_pk: comment_pk || null,
+          user_pk: user.pk,
+          user_name: user[user.type].name,
+          content: content || null,
+        },
+      });
+
+      if (!created && result.content !== content) {
+        await result.update({
+          content,
+        });
+      }
+
+      await res.json({
+        success: true,
+      });
+    } else {
+      next(new CustomError({ name: 'Wrong_Data' }));
+    }
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
+};
+
+export default report;

--- a/routes/middlewares/meal/order/getMealOrder.ts
+++ b/routes/middlewares/meal/order/getMealOrder.ts
@@ -1,14 +1,16 @@
 import { NextFunction, Request, Response } from 'express';
 
+import CustomError from '@Middleware/error/customError';
 import MealOrder from '@Model/mealOrder.model';
 
 const mealOrder = async (req: Request, res: Response, next: NextFunction) => {
   const result: MealOrder[] = await MealOrder.findAll();
+  const order = result[0].order;
 
   await res.json({
     success: true,
     data: {
-      order: result[0].order,
+      order: order || '조회된 데이터가 없습니다.',
     },
   });
 };

--- a/routes/middlewares/notice/_validation.ts
+++ b/routes/middlewares/notice/_validation.ts
@@ -1,4 +1,4 @@
-import { oneOf, query, ValidationChain } from 'express-validator/check';
+import { oneOf, query } from 'express-validator/check';
 
 const getNoticeValidation = oneOf([
   [

--- a/routes/middlewares/user/common/userExistCheck.ts
+++ b/routes/middlewares/user/common/userExistCheck.ts
@@ -1,45 +1,64 @@
 import { NextFunction, Request, Response } from 'express';
 
 import CustomError from '@Middleware/error/customError';
+
+import Graduate from '@Model/graduate.model';
+import Parent from '@Model/parent.model';
 import Student from '@Model/student.model';
 import Teacher from '@Model/teacher.model';
 import User from '@Model/user.model';
 
-const userExistCheck = (req: Request, res: Response, next: NextFunction) => {
+const userExistCheck = async (req: Request, res: Response, next: NextFunction) => {
   const { id } = req.body;
 
-  User.findOne({
-    where: {
-      id,
-    },
-    include: [
-      {
-        model: Student,
+  try {
+    const user: User | undefined = await User.findOne({
+      where: {
+        id,
       },
-      {
-        model: Teacher,
-      },
-    ],
-  })
-    .then((user: User) => {
-      switch (req.path) {
-        case '/register':
-          user ? next(new CustomError({ name: 'Exist_User' })) : next();
+    });
+
+    if (user) {
+      switch (user.type) {
+        case 'student':
+          const stduent: Student = await Student.findOne({ where: { user_pk: user.pk } });
+          user.student = stduent;
           break;
-        case '/login':
-          if (user) {
-            res.locals.user = user;
-            next();
-          } else {
-            next(new CustomError({ name: 'Not_User', message: '등록되지 않은 아이디이거나, 아이디 또는 비밀번호를 잘못 입력하셨습니다.' }));
-          }
+
+        case 'parent':
+          const parent: Parent = await Parent.findOne({ where: { user_pk: user.pk } });
+          user.parent = parent;
+          break;
+
+        case 'teacher':
+          const teacher: Teacher = await Teacher.findOne({ where: { user_pk: user.pk } });
+          user.teacher = teacher;
+          break;
+
+        case 'graduate':
+          const graduate: Graduate = await Graduate.findOne({ where: { user_pk: user.pk } });
+          user.graduate = graduate;
           break;
       }
-    })
-    .catch(err => {
-      console.log(err);
-      next(new CustomError({ name: 'Database_Error' }));
-    });
+    }
+
+    switch (req.path) {
+      case '/register':
+        user ? next(new CustomError({ name: 'Exist_User' })) : next();
+        break;
+      case '/login':
+        if (user) {
+          res.locals.user = user;
+          next();
+        } else {
+          next(new CustomError({ name: 'Not_User', message: '등록되지 않은 아이디이거나, 아이디 또는 비밀번호를 잘못 입력하셨습니다.' }));
+        }
+        break;
+    }
+  } catch (error) {
+    console.log(error);
+    next(new CustomError({ name: 'Database_Error' }));
+  }
 };
 
 export default userExistCheck;

--- a/routes/middlewares/user/jwt/getUserFromToken.ts
+++ b/routes/middlewares/user/jwt/getUserFromToken.ts
@@ -1,6 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
 
 import CustomError from '@Middleware/error/customError';
+
+import Graduate from '@Model/graduate.model';
+import Parent from '@Model/parent.model';
 import Student from '@Model/student.model';
 import Teacher from '@Model/teacher.model';
 import User from '@Model/user.model';
@@ -12,17 +15,30 @@ const getUserFromToken = async (req: Request, res: Response, next: NextFunction)
       where: {
         pk,
       },
-      include: [
-        {
-          model: Teacher,
-        },
-        {
-          model: Student,
-        },
-      ],
     });
 
     if (user) {
+      switch (user.type) {
+        case 'student':
+          const stduent: Student = await Student.findOne({ where: { user_pk: user.pk } });
+          user.student = stduent;
+          break;
+
+        case 'parent':
+          const parent: Parent = await Parent.findOne({ where: { user_pk: user.pk } });
+          user.parent = parent;
+          break;
+
+        case 'teacher':
+          const teacher: Teacher = await Teacher.findOne({ where: { user_pk: user.pk } });
+          user.teacher = teacher;
+          break;
+
+        case 'graduate':
+          const graduate: Graduate = await Graduate.findOne({ where: { user_pk: user.pk } });
+          user.graduate = graduate;
+          break;
+      }
       res.locals.user = user;
       next();
     } else {

--- a/routes/middlewares/user/jwt/issueToken.ts
+++ b/routes/middlewares/user/jwt/issueToken.ts
@@ -12,6 +12,7 @@ const issueToken = (req: Request, res: Response, next: NextFunction) => {
     },
     tokenSecret
   );
+
   res.json({
     success: true,
     data: {
@@ -19,11 +20,11 @@ const issueToken = (req: Request, res: Response, next: NextFunction) => {
       user: {
         type: user.type,
         admin: user.admin,
-        name: (user.student && user.student.name) || user.teacher.name,
-        major: user.student ? user.student.major : null,
-        grade: user.student ? user.student.grade : null,
-        classNum: user.student ? user.student.classNum : null,
-        studentNum: user.student ? user.student.studentNum : null,
+        name: user[user.type].name,
+        major: user.type === 'student' ? user.student.major : null,
+        grade: user.type === 'student' ? user.student.grade : null,
+        classNum: user.type === 'student' ? user.student.classNum : null,
+        studentNum: user.type === 'student' ? user.student.studentNum : null,
       },
     },
   });

--- a/swagger.json
+++ b/swagger.json
@@ -618,7 +618,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["student", "teacher"]
+            "enum": ["student", "teacher", "graduate", "parent"]
           },
           "admin": {
             "type": "integer"


### PR DESCRIPTION
swagger.json, (graduate • parent).model.ts, userExistCheck.ts, getUserFromToken.ts, issueToken.ts
- Add two types of users and respond to new types

(board • boardComment • boardPatchLog • boardReportLog).model.ts
- New models for board APIs

checkUserType.ts
- Only student and graudate can go next middleware

getBoard.ts, postBoard.ts, patchBoard.ts, deleteBoard.ts
- Board CRUD middlewares

getComment.ts, postComment.ts, patchComment.ts, deleteComment.ts
- Comment CRUD middlewares

report.ts
- Users can report some boards or comments but if they reported more than once, it is updated on it and doesn't create more than two rows