### PR TITLE
 fixed: POST /user/phone doesn't change user's tp

### DIFF
--- a/routes/middlewares/user/patch/phone/_validation.ts
+++ b/routes/middlewares/user/patch/phone/_validation.ts
@@ -1,7 +1,5 @@
 import { body, ValidationChain } from 'express-validator/check';
 
-import { tp } from '@Lib/pattern.json';
-
 const userPatchPhone: ValidationChain[] = [body('code').isString()];
 
 export default userPatchPhone;

--- a/routes/middlewares/user/phone/phoneCheck.ts
+++ b/routes/middlewares/user/phone/phoneCheck.ts
@@ -22,7 +22,11 @@ const phoneCheck = (req: Request, res: Response, next: NextFunction) => {
 
         case '/phone':
           if (user) {
-            next(new CustomError({ name: 'Exist_User', message: '사용 중인 전화번호입니다.' }));
+            if (res.locals.user && res.locals.user.pk === user.pk) {
+              res.sendStatus(204);
+            } else {
+              next(new CustomError({ name: 'Exist_User', message: '사용 중인 전화번호입니다.' }));
+            }
           } else {
             next();
           }

--- a/routes/middlewares/user/register/signKeyCheck.ts
+++ b/routes/middlewares/user/register/signKeyCheck.ts
@@ -15,7 +15,7 @@ const signKeyCheck = (req: Request, res: Response, next: NextFunction) => {
       if (user && user.signKey === signKey) {
         if (req.path.includes('/phone')) {
           res.locals.user = user;
-          user.tp ? res.sendStatus(204) : next();
+          next();
         } else if (user.tp) {
           res.locals.user = user;
           next();

--- a/swagger.json
+++ b/swagger.json
@@ -96,7 +96,7 @@
             }
           },
           "204": {
-            "description": "회원 중에 이미 번호를 가진 유저가 있어서 다음 프로세스를 진행하지 않아도 됨"
+            "description": "유저가 이미 해당 전화번호인 것이 증명되었기 때문에 다음 프로세스를 진행하지 않음"
           },
           "401": {
             "description": "(Wrong_Request) facebook account kit으로 요청된 code값이 잘못됨"
@@ -144,6 +144,9 @@
                 }
               }
             }
+          },
+          "204": {
+            "description": "유저가 이미 해당 전화번호인 것이 증명되었기 때문에 다음 프로세스를 진행하지 않음"
           },
           "401": {
             "description": "(Wrong_Request) facebook account kit으로 요청된 code값이 잘못됨"


### PR DESCRIPTION
If user has already tp, POST /user/phone is not working.
Status 204 will be sent later than original process.